### PR TITLE
feat: translate to ES

### DIFF
--- a/components/Faq.js
+++ b/components/Faq.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import i18n from '../lib/i18n';
+import isSupportedLocale from '../lib/locales';
 
 class Faq extends React.Component {
   renderFaqItem(faq) {
@@ -18,7 +19,7 @@ class Faq extends React.Component {
   render() {
     i18n.locale = this.props.locale;
 
-    if (this.props.locale === "es-ES") {
+    if (!isSupportedLocale(this.props.locale)) {
       return <div />
     }
 

--- a/components/FreeChapter.js
+++ b/components/FreeChapter.js
@@ -1,11 +1,12 @@
 import React from 'react';
 import i18n from '../lib/i18n';
+import isSupportedLocale from '../lib/locales';
 
 class FreeChapter extends React.Component {
   render() {
     i18n.locale = this.props.locale;
 
-    if (this.props.locale === "es-ES") {
+    if (!isSupportedLocale(this.props.locale)) {
       return <div />
     }
 

--- a/components/FreeChapter.js
+++ b/components/FreeChapter.js
@@ -1,12 +1,11 @@
 import React from 'react';
 import i18n from '../lib/i18n';
-import isSupportedLocale from '../lib/locales';
 
 class FreeChapter extends React.Component {
   render() {
     i18n.locale = this.props.locale;
 
-    if (!isSupportedLocale(this.props.locale)) {
+    if (this.props.locale === "es-ES") {
       return <div />
     }
 

--- a/components/Interviews.js
+++ b/components/Interviews.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import i18n from '../lib/i18n';
+import isSupportedLocale from '../lib/locales';
 
 class Interviews extends React.Component {
   state = {
@@ -165,7 +166,7 @@ class Interviews extends React.Component {
   render() {
     i18n.locale = this.props.locale;
 
-    if (this.props.locale === "es-ES") {
+    if (!isSupportedLocale(this.props.locale)) {
       return <div />
     }
 

--- a/components/Logos.js
+++ b/components/Logos.js
@@ -1,11 +1,12 @@
 import React from 'react';
 import i18n from '../lib/i18n';
+import isSupportedLocale from '../lib/locales';
 
 class Logos extends React.Component {
   render() {
     i18n.locale = this.props.locale;
 
-    if (this.props.locale === "es-ES") {
+    if (!isSupportedLocale(this.props.locale)) {
       return <div />
     }
 

--- a/components/Pricing.js
+++ b/components/Pricing.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import i18n from '../lib/i18n';
 import getPricing from '../lib/pricing';
+import isSupportedLocale from '../lib/locales';
 
 class Pricing extends React.Component {
   constructor(props) {
@@ -20,7 +21,7 @@ class Pricing extends React.Component {
   render() {
     i18n.locale = this.props.locale;
 
-    if (this.props.locale === "es-ES") {
+    if (!isSupportedLocale(this.props.locale)) {
       return <div />
     }
 

--- a/components/Testimonials.js
+++ b/components/Testimonials.js
@@ -1,11 +1,12 @@
 import React from 'react';
 import i18n from '../lib/i18n';
+import isSupportedLocale from '../lib/locales';
 
 class Testimonials extends React.Component {
   render() {
     i18n.locale = this.props.locale;
 
-    if (this.props.locale === "es-ES") {
+    if (!isSupportedLocale(this.props.locale)) {
       return <div />
     }
 

--- a/components/Toc.js
+++ b/components/Toc.js
@@ -1,11 +1,12 @@
 import React from 'react';
 import i18n from '../lib/i18n';
+import isSupportedLocale from '../lib/locales';
 
 class Toc extends React.Component {
   render() {
     i18n.locale = this.props.locale;
 
-    if (this.props.locale === "es-ES") {
+    if (!isSupportedLocale(this.props.locale)) {
       return <div />
     }
 

--- a/lib/locales.js
+++ b/lib/locales.js
@@ -1,0 +1,7 @@
+const supportedLocales = ['en-US', 'pt-BR', 'es-ES']
+
+function isSupportedLocale(locale) {
+    return supportedLocales.includes(locale)
+}
+
+export default isSupportedLocale;

--- a/package-lock.json
+++ b/package-lock.json
@@ -2796,9 +2796,9 @@
       "integrity": "sha512-utucmBYnRyjO3GCsgn7vwTJyDWIyftZW5vuGoxHj2Mnt6yF/alOq1ZGqBGNVZs/vKvgfNZu56y5xpn37i3n0ew=="
     },
     "elliptic": {
-      "version": "6.5.2",
-      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.2.tgz",
-      "integrity": "sha512-f4x70okzZbIQl/NSRLkI/+tteV/9WqL98zx+SQ69KbXxmVrmjwsNUPn/gYJJ0sHvEak24cZgHIPegRePAtA/xw==",
+      "version": "6.5.3",
+      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.3.tgz",
+      "integrity": "sha512-IMqzv5wNQf+E6aHeIqATs0tOLeOTwj1QKbRcS3jBbYkl5oLAserA8yJTT7/VyHUYG91PRmPyeQDObKLPpeS4dw==",
       "requires": {
         "bn.js": "^4.4.0",
         "brorand": "^1.0.1",
@@ -2810,9 +2810,9 @@
       },
       "dependencies": {
         "bn.js": {
-          "version": "4.11.8",
-          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
-          "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA=="
+          "version": "4.11.9",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.9.tgz",
+          "integrity": "sha512-E6QoYqCKZfgatHTdHzs1RRKP7ip4vvm+EyRUeE2RF0NblwVvb0p6jSVeNTOFxPn26QXN2o6SMfNxKp6kU8zQaw=="
         }
       }
     },
@@ -5985,9 +5985,12 @@
       "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
     },
     "serialize-javascript": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-2.1.2.tgz",
-      "integrity": "sha512-rs9OggEUF0V4jUSecXazOYsLfu7OGK2qIn3c7IPBiffz32XniEp/TX9Xmc9LQfK2nQ2QKHvZ2oygKUGU0lG4jQ=="
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-4.0.0.tgz",
+      "integrity": "sha512-GaNA54380uFefWghODBWEGisLZFj00nS5ACs6yHa9nLqlLpVLO8ChDGeKRjZnV4Nh4n0Qi7nhYZD/9fCPzEqkw==",
+      "requires": {
+        "randombytes": "^2.1.0"
+      }
     },
     "set-value": {
       "version": "2.0.1",
@@ -6576,15 +6579,15 @@
       }
     },
     "terser-webpack-plugin": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-1.4.3.tgz",
-      "integrity": "sha512-QMxecFz/gHQwteWwSo5nTc6UaICqN1bMedC5sMtUc7y3Ha3Q8y6ZO0iCR8pq4RJC8Hjf0FEPEHZqcMB/+DFCrA==",
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-1.4.5.tgz",
+      "integrity": "sha512-04Rfe496lN8EYruwi6oPQkG0vo8C+HT49X687FZnpPF0qMAIHONI6HEXYPKDOE8e5HjXTyKfqRd/agHtH0kOtw==",
       "requires": {
         "cacache": "^12.0.2",
         "find-cache-dir": "^2.1.0",
         "is-wsl": "^1.1.0",
         "schema-utils": "^1.0.0",
-        "serialize-javascript": "^2.1.2",
+        "serialize-javascript": "^4.0.0",
         "source-map": "^0.6.1",
         "terser": "^4.1.2",
         "webpack-sources": "^1.4.0",

--- a/pages/es/bonus/2.js
+++ b/pages/es/bonus/2.js
@@ -1,0 +1,28 @@
+import React from 'react';
+import Bonus from '../../../components/Bonus';
+
+class BonusTwoSpanish extends React.Component {
+  render() {
+    const convertKit = {
+      form: '1508570',
+      uid: '36ae5250a0'
+    };
+
+    return <Bonus
+      habit="2"
+      convertKit={convertKit}
+      query={this.props.query}
+      locale="es-ES"
+    />
+  }
+}
+
+export async function getServerSideProps(context) {
+  const { query } = context;
+
+  return {
+    props: { query }
+  }
+}
+
+export default BonusTwoSpanish;

--- a/pages/es/bonus/5.js
+++ b/pages/es/bonus/5.js
@@ -1,0 +1,28 @@
+import React from 'react';
+import Bonus from '../../../components/Bonus';
+
+class BonusFiveSpanish extends React.Component {
+  render() {
+    const convertKit = {
+      form: '1508416',
+      uid: 'c8d5589dec'
+    };
+
+    return <Bonus
+      habit="5"
+      convertKit={convertKit}
+      query={this.props.query}
+      locale="es-ES"
+    />
+  }
+}
+
+export async function getServerSideProps(context) {
+  const { query } = context;
+
+  return {
+    props: { query }
+  }
+}
+
+export default BonusFiveSpanish;

--- a/pages/es/bonus/8.js
+++ b/pages/es/bonus/8.js
@@ -1,0 +1,28 @@
+import React from 'react';
+import Bonus from '../../../components/Bonus';
+
+class BonusEightSpanish extends React.Component {
+  render() {
+    const convertKit = {
+      form: '1508679',
+      uid: '32f00b8460'
+    };
+
+    return <Bonus
+      habit="8"
+      convertKit={convertKit}
+      query={this.props.query}
+      locale="es-ES"
+    />
+  }
+}
+
+export async function getServerSideProps(context) {
+  const { query } = context;
+
+  return {
+    props: { query }
+  }
+}
+
+export default BonusEightSpanish;


### PR DESCRIPTION
## What does this PR do?
It creates the pages for the bonus section, under the Spanish lang. Besides that, it is adding a simple function to allow the UI components to render if the current locale is supported. This function will hold a reference to the supported locales and will use Javascript's includes method to check if the passed in locale is supported. Then, the component will only return an empty `<div />` if the locale is not supported.

>Supported locales: en-US, pt-BR, es-ES

You'll notice this reverted commit: 5dfc8a75f5f5e5cb4117f369fa97ee217c67b564. Please re-add it back once you have the free chapter PDF for the Spanish lang.

As a side note, we fixed some NPM security issues with `npm audit fix`


## Why is it important?
More translations

## Related issues
- Relates #4

## Follow-ups
We need the spanish image for the kindle

## Other concerns
I tried to move to `static/build-time generation` (https://nextjs.org/docs/basic-features/data-fetching#getstaticprops-static-generation) without success, because the query is not serialisable, and this query is only used in the Alert component. Any guess?